### PR TITLE
Extra build dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+nodejs 19.0.1
+golang 1.19.3

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CLEVER_DEVICES_KEY?=""
 CLEVER_DEVICES_IP?=""
 
 build:
+	npm install
 	npm run build
 	go build
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ getting around the city extremely frustrating. This map is just a stop gap to ge
 
 You need to get the key from Ben on Slack in #civic-hacking. If you aren't in the NOLA Devs slack here is an invite: https://nola.slack.com/join/shared_invite/zt-4882ja82-iGm2yO6KCxsi2aGJ9vnsUQ
 
-You need a few things deps your machine:
+You need a few things your machine on your machine to build the project. If you are an `asdf` user there is a .tool-versions file with acceptable versions of node, npm, and go, but not make to keep from conflicting with system build tools.
 
 * node and npm
 * go


### PR DESCRIPTION
Adds a .tool-versions with the latest nodejs and golang versions as well as calls `npm install` in the makefile.