### PR TITLE
Migrate from Buildpack to Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.22.6-alpine AS builder
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 
 FROM alpine:latest
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates tzdata
 
 WORKDIR /root/
 COPY --from=builder /app/main .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+COPY --from=builder /app/main .
+COPY --from=builder /app/public ./public
+
+EXPOSE 8080
+
+CMD ["./main"]

--- a/fly.toml
+++ b/fly.toml
@@ -6,11 +6,6 @@ kill_timeout = 5
 processes = []
 
 [build]
-  builder = "paketobuildpacks/builder:base"
-  buildpacks = ["gcr.io/paketo-buildpacks/go"]
-
-[build.args]
-  BP_KEEP_FILES = "public/*"
 
 [env]
   PORT = "8080"

--- a/main.go
+++ b/main.go
@@ -235,7 +235,11 @@ func (v *Scraper) fetch() (*BustimeData) {
 	}
 
 	result := &BustimeResponse{}
-	json.Unmarshal(body, result)
+	if err := json.Unmarshal(body, result); err != nil {
+		log.Printf("ERROR: JSON unmarshal failed: %v", err)
+		log.Printf("Response body (first 500 chars): %s", string(body)[:min(500, len(body))])
+		return &BustimeData{}
+	}
 
 	return &result.Data
 }


### PR DESCRIPTION
Fly no longer uses this buildpack, which is why the gcr link was failing. This switches us to a Docker based deploy.

Closes #52